### PR TITLE
Fix Stage 2 Article Filtering for users who have voted

### DIFF
--- a/frontend/components/StageButton/index.tsx
+++ b/frontend/components/StageButton/index.tsx
@@ -34,7 +34,7 @@ export const StageButton = ({
         [styles.active]: currentVotingStage == value,
         [styles.disabled]: availableStage != value,
       })}
-      onClick={() => onButtonClick(1)}
+      onClick={() => onButtonClick(value)}
       disabled={availableStage != value}
     >
       {children}

--- a/frontend/components/StageButton/index.tsx
+++ b/frontend/components/StageButton/index.tsx
@@ -21,6 +21,7 @@ export const StageButton = ({
 }: Props) => {
   const [ availableStage, setAvailableStage ] = useState<number | undefined>(undefined);
   const availableVotingStage = useAppSelector(selectAvailableVotingStage);
+  const isDisabled = !availableStage || availableStage < value;
 
   useEffect(() => {
     setAvailableStage(availableVotingStage);
@@ -32,10 +33,10 @@ export const StageButton = ({
         [styles.filterStageButton]: !isMobile,
         [styles.filterStageButtonMobile]: isMobile,
         [styles.active]: currentVotingStage == value,
-        [styles.disabled]: availableStage != value,
+        [styles.disabled]: isDisabled,
       })}
       onClick={() => onButtonClick(value)}
-      disabled={availableStage != value}
+      disabled={isDisabled}
     >
       {children}
     </button>


### PR DESCRIPTION
# Fix Stage 2 Article Filtering for users who have voted

## Purpose and Scope:
This pull request addresses the issue where logged-in users who have already voted are unable to use the stage 2 filter to view articles that have advanced to stage 2 (articles with received votes). Additionally, this PR ensures consistent messaging between the ModalNote and the top banner regarding the user’s voting status.

I believe these changes will greatly enhance the usability of the system for users who have already participated in the voting process. Please review the code changes and provide your feedback.

## Changes Made

- pass value prop to onButtonClick handler in StageButton component

## How to Test These Changes:

To test these changes, follow these steps:
1. Build site or run dev server
2. Visit home page and user should be unable to select any stage filter buttons
3. Log in to the system using a user account that has not previously cast votes.
4. User should be able to filter by stage 1 articles.
5. Verify that the filter functions correctly and displays articles that have reached stage 1.
6. Cast a vote 
7. User should be able to filter by stage 1 articles as well as stage 2 articles
8. Verify that the filter functions correctly and displays articles that have reached stage 2
9. Check both the ModalNote and the top banner for accurate and consistent voting status information.

## Related Issues

Fixes #237  